### PR TITLE
解决微博防盗链导致图片不显示的问题

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -31,7 +31,7 @@ const defaultConfig = {
     apiDetail: 7 * 24 * 60 * 60,
     apiDomain: 7 * 24 * 60 * 60,
   },
-  imageCache:'https://image.baidu.com/search/down?url='
+  imageCache: 'https://image.baidu.com/search/down?url=',
 };
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,7 @@ const defaultConfig = {
     apiDetail: 7 * 24 * 60 * 60,
     apiDomain: 7 * 24 * 60 * 60,
   },
+  imageCache:'https://image.baidu.com/search/down?url='
 };
 
 /**

--- a/src/modules/weibo/weibo.ts
+++ b/src/modules/weibo/weibo.ts
@@ -114,8 +114,8 @@ export const statusToHTML = (status: WeiboStatus) => {
   if (status.pics) {
     status.pics.forEach(function (item) {
       tempHTML += "<br><br>";
-      var url = config.imageCache ? (config.imageCache + encodeURIComponent(item.url)) : item.url;
-      let largeUrl = config.imageCache ? (config.imageCache + encodeURIComponent(item.large.url)) : item.large.url;
+      const url = config.imageCache ? (config.imageCache + encodeURIComponent(item.url)) : item.url;
+      const largeUrl = config.imageCache ? (config.imageCache + encodeURIComponent(item.large.url)) : item.large.url;
       tempHTML += '<a href="' + largeUrl + '" target="_blank"><img src="' + url+ '"></a>';
     });
   }

--- a/src/modules/weibo/weibo.ts
+++ b/src/modules/weibo/weibo.ts
@@ -114,7 +114,9 @@ export const statusToHTML = (status: WeiboStatus) => {
   if (status.pics) {
     status.pics.forEach(function (item) {
       tempHTML += "<br><br>";
-      tempHTML += '<a href="' + item.large.url + '" target="_blank"><img src="' + item.url + '"></a>';
+      var url = config.imageCache ? (config.imageCache + encodeURIComponent(item.url)) : item.url;
+      var largeUrl = config.imageCache? (config.imageCache + encodeURIComponent(item.large.url)) : item.large.url;
+      tempHTML += '<a href="' + largeUrl + '" target="_blank"><img src="' + url+ '"></a>';
     });
   }
 

--- a/src/modules/weibo/weibo.ts
+++ b/src/modules/weibo/weibo.ts
@@ -115,7 +115,7 @@ export const statusToHTML = (status: WeiboStatus) => {
     status.pics.forEach(function (item) {
       tempHTML += "<br><br>";
       var url = config.imageCache ? (config.imageCache + encodeURIComponent(item.url)) : item.url;
-      var largeUrl = config.imageCache? (config.imageCache + encodeURIComponent(item.large.url)) : item.large.url;
+      let largeUrl = config.imageCache ? (config.imageCache + encodeURIComponent(item.large.url)) : item.large.url;
       tempHTML += '<a href="' + largeUrl + '" target="_blank"><img src="' + url+ '"></a>';
     });
   }


### PR DESCRIPTION
https://github.com/zgq354/weibo-rss/issues/57
https://github.com/zgq354/weibo-rss/issues/59


直接的做法是修改referrer，但是inoreader不支持修改referer,于是使用图片缓存站（百度）的方式解决