### PR TITLE
feat: Adjust the image display logic to show the original image.

### DIFF
--- a/src/modules/weibo/weibo.ts
+++ b/src/modules/weibo/weibo.ts
@@ -125,7 +125,7 @@ export const statusToHTML = (status: WeiboStatus) => {
   if (status.pics) {
     status.pics.forEach(function (item) {
       tempHTML += "<br><br>";
-      const url = config.imageCache ? (config.imageCache + encodeURIComponent(item.url)) : item.url;
+      const url = config.imageCache ? (config.imageCache + encodeURIComponent(item.large.url)) : item.large.url;
       const largeUrl = config.imageCache ? (config.imageCache + encodeURIComponent(item.large.url)) : item.large.url;
       tempHTML += '<a href="' + largeUrl + '" target="_blank"><img src="' + url+ '"></a>';
     });


### PR DESCRIPTION
This pull request includes a change to the `statusToHTML` function in the `src/modules/weibo/weibo.ts` file. The change ensures that the image URL used for the `img` tag is the large version of the image.

* [`src/modules/weibo/weibo.ts`](diffhunk://#diff-e196f158c756a08d57f76f3590e3210a43e73ca685283c443d21f8d21cad900dL128-R128): Modified the `statusToHTML` function to use the large version of the image URL for the `img` tag.

#70 关联问题,图片被压缩.